### PR TITLE
bugfix/I10-fix-infinite-loop-for-clockify-entries

### DIFF
--- a/src/tools/Clockify.ts
+++ b/src/tools/Clockify.ts
@@ -8,6 +8,7 @@ import {
   ClientDto as ClockifyClientResponse,
   CreateProjectRequest as ClockifyProjectRequest,
   CreateTimeEntryRequest as ClockifyTimeEntryRequest,
+  EstimateType,
   ProjectDtoImpl as ClockifyProjectResponse,
   TimeEntryFullDto as ClockifyTimeEntryResponse,
 } from '../types/clockify';
@@ -339,6 +340,8 @@ export default class Clockify {
 
     this.entityIndex = 0;
 
+    // TODO: Fix "estimate" field to reflect Toggl.
+    //       For now, changing it on Clockify shouldn't take too much work.
     await this.transferEntitiesFromToggl<ClockifyProjectRequest>(
       workspace,
       EntityGroup.Projects,
@@ -346,7 +349,10 @@ export default class Clockify {
         name: togglProject.name,
         clientId: getClientIdForProject(togglProject),
         isPublic: false,
-        estimate: 0,
+        estimate: {
+          estimate: 0,
+          type: EstimateType.Manual,
+        },
         color: togglProject.hex_color,
         billable: togglProject.billable,
       }),

--- a/src/types/clockify.ts
+++ b/src/types/clockify.ts
@@ -83,7 +83,7 @@ export interface CreateProjectRequest {
   name: string;
   clientId: string;
   isPublic: boolean;
-  estimate: string;
+  estimate: EstimateDto;
   color: string;
   billable: boolean;
 }


### PR DESCRIPTION
## Overview of Changes
- Update `CreateProjectRequest` type and corresponding implementation to ensure projects are being created

## Reference Issues/Pull Requests
- Infinite loop when transferring time entries to Clockify (#10)